### PR TITLE
Fix a few things

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -14,7 +14,9 @@
 
 model:
   # paths
-  llama_path: "/mnt/dssk/data_rw/shubham/l2p/llama3"
+  # llama_path: "/mnt/dssk/data_rw/shubham/l2p/llama3"
+  llama_model_name: "meta-llama/Meta-Llama-3-8B"
+  cache_dir: "/mnt/dssk/data_rw/shubham/l2p/llama3"
   whisper_path: "/mnt/dssk/data_rw/shubham/l2p/whisper/"
   beats_path: "/mnt/dssk/data_rw/shubham/l2p/beats/BEATs_iter3_plus_AS2M_finetuned_on_AS2M_cpt2.pt"
 

--- a/models/salmonn.py
+++ b/models/salmonn.py
@@ -165,12 +165,6 @@ class SALMONN(nn.Module):
             llama_model_name,
             cache_dir=cache_dir
         )
-        if self.llama_tokenizer.pad_token is None:
-            self.llama_tokenizer.add_special_tokens({'pad_token': '[PAD]'})  
-            self.llama_model.resize_token_embeddings(len(self.llama_tokenizer))
-      
-        self.llama_tokenizer.padding_side = "right"
-
         
         logging.info('Loading LLaMA Model')
         if self.low_resource:
@@ -187,6 +181,12 @@ class SALMONN(nn.Module):
                 cache_dir=cache_dir,
                 torch_dtype=torch.float16
             )
+            
+        if self.llama_tokenizer.pad_token is None:
+            logging.info("There is no pad token present, using eos token instead")
+            self.llama_tokenizer.pad_token = self.llama_tokenizer.eos_token
+      
+        self.llama_tokenizer.padding_side = "right"
             
         for name, param in self.llama_model.named_parameters():
             param.requires_grad = False


### PR DESCRIPTION
- The bug in soft ptompt and pool prompts wrt ignoring the tokens for accuracy cacluculation 
- This now loads the LLM model from HF name and adds it to a cache, so that we cn experiment with different LMs easily without having to load them apriori
- This does not learn a new PAD token, but instead uses <end_of_sequence> token as the pad token, as i have seen other pipelines do...