### PR TITLE
Fixing a few things from discussion today! 

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -15,7 +15,7 @@
 model:
   # paths
   # llama_path: "/mnt/dssk/data_rw/shubham/l2p/llama3"
-  llama_model_name: "meta-llama/Meta-Llama-3-8B"
+  llama_model_name: "lmsys/vicuna-13b-v1.1"
   cache_dir: "/mnt/dssk/data_rw/shubham/l2p/llama3"
   whisper_path: "/mnt/dssk/data_rw/shubham/l2p/whisper/"
   beats_path: "/mnt/dssk/data_rw/shubham/l2p/beats/BEATs_iter3_plus_AS2M_finetuned_on_AS2M_cpt2.pt"
@@ -69,6 +69,8 @@ run:
   seed: 42
   output_dir: "baseline_run_wandb"
   evaluate: False # if True, only evaluate model on test data
+
+  valid_iters: 25
 
   log_freq: 5
   epoch_based: False

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -60,12 +60,9 @@ model:
   end_sym: "</s>"
 
 datasets:
-  train_ann_path: "/home/toolkit/SALMONN/data/IEMOCAP/ie-train.json"
-  valid_ann_path: "/home/toolkit/SALMONN/data/IEMOCAP/ie-valid.json"
-  test_ann_path: "/home/toolkit/SALMONN/data/IEMOCAP/ie-test.json"
-
+  # possible options right now are "librisqa", "libriasr", "er"
+  dataset: "libriasr"
   whisper_path: "/mnt/dssk/data_rw/shubham/l2p/whisper/"
-  data_root: "users/rwhetten/IEMOCAP/IEMOCAP_full_release/"
 
 run:
   # log & settings

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -60,7 +60,7 @@ model:
   end_sym: "</s>"
 
 datasets:
-  # possible options right now are "librisqa", "libriasr", "er"
+  # possible options right now are "librisqa", "libriasr", "er", "clotho_audio_cap"
   dataset: "libriasr"
   whisper_path: "/mnt/dssk/data_rw/shubham/l2p/whisper/"
 

--- a/dataset.py
+++ b/dataset.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import torchaudio
 
 import torch
 from torch.utils.data import Dataset
@@ -68,6 +69,11 @@ class SALMONNDataset(Dataset):
         audio, sr = sf.read(ann["path"])
         if len(audio.shape) == 2: # stereo to mono
             audio = audio[:, 0]
+        if sr != 16000:
+            audio_tensor = torch.tensor(audio, dtype=torch.float32)
+            audio_tensor = torchaudio.functional.resample(audio_tensor, sr, 16000)
+            audio = audio_tensor.numpy()
+            sr = 16000
         if "expand_wav" in ann:
             for p in ann["expand_wav"]:
                 expand_audio, _ = sf.read(p)

--- a/models/salmonn.py
+++ b/models/salmonn.py
@@ -178,9 +178,10 @@ class SALMONN(nn.Module):
             )
             
         if self.llama_tokenizer.pad_token is None:
-            logging.info("There is no pad token present, using eos token instead")
-            self.llama_tokenizer.pad_token = self.llama_tokenizer.eos_token
-      
+            logging.info("There is no pad token present, learning a new one instead")
+            self.llama_tokenizer.add_special_tokens({'pad_token': '[PAD]'})
+            self.llama_model.resize_token_embeddings(len(self.llama_tokenizer))
+        
         self.llama_tokenizer.padding_side = "right"
             
         for name, param in self.llama_model.named_parameters():

--- a/models/salmonn.py
+++ b/models/salmonn.py
@@ -565,7 +565,7 @@ class SALMONN(nn.Module):
             length_penalty=generate_cfg.get("length_penalty", 1.0),
             attention_mask=attns,
         )
-        text = self.llama_tokenizer.batch_decode(outputs, add_special_tokens=False)
+        text = self.llama_tokenizer.batch_decode(outputs, add_special_tokens=False, skip_special_tokens=True)
 
         return text
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,7 @@ accelerate==0.20.3
 bitsandbytes==0.45.1
 gradio==3.23.0
 wandb==0.19.6
-nltk==3.9.1
+# nltk==3.9.1
 rouge-score==0.1.2
+evaluate-0.4.3
+jiwer-3.1.0

--- a/runner.py
+++ b/runner.py
@@ -231,7 +231,7 @@ class Runner:
                 total_correct += exact_matches.sum()
 
                 # **BLEU & ROUGE-L Preparation**
-                all_references.extend([[t] for t in ground_truths])
+                all_references.extend(ground_truths)
                 all_hypotheses.extend(generated_texts)
 
             results.append({
@@ -249,12 +249,12 @@ class Runner:
 
         # **Compute Corpus-Level BLEU Score**
         bleu_start_time = time.time()
-        bleu_score = bleu_metric.compute(predictions=all_hypotheses, references=all_references)["bleu"]
+        bleu_score = bleu_metric.compute(predictions=all_hypotheses, references=[[ref] for ref in all_references])["bleu"]
         bleu_time = time.time() - bleu_start_time
 
         # **Compute Corpus-Level ROUGE-L and Rouge-4 Score**
         rouge_start_time = time.time()
-        rouge_scores = rouge_metric.compute(predictions=all_hypotheses, references=all_references)
+        rouge_scores = rouge_metric.compute(predictions=all_hypotheses, references=[[ref] for ref in all_references])
         total_rouge4_score = sum(
             rouge_scorer_obj.score(ref, hyp)["rouge4"].fmeasure
             for ref, hyp in zip(all_references, all_hypotheses)

--- a/train.py
+++ b/train.py
@@ -73,6 +73,14 @@ def get_paths(dataset_name):
             "valid": "/home/toolkit/SALMONN/data/IEMOCAP/ie-valid-full.json",
             "data_root": "users/rwhetten/IEMOCAP/IEMOCAP_full_release/",
         }
+    if dataset_name == "clotho_audio_cap":
+        return {
+            "train": "/home/toolkit/SALMONN/data/CLOTHIO_AUDIOCAP/clotho_captions_development.json",
+            "test": "/home/toolkit/SALMONN/data/CLOTHIO_AUDIOCAP/clotho_captions_validation.json",
+            "valid": "/home/toolkit/SALMONN/data/CLOTHIO_AUDIOCAP/clotho_captions_development.json",
+            "data_root": "/mnt/dssk/data_rw/shubham/l2p/clotho/",
+        }    
+    
 
 
 def main():

--- a/train.py
+++ b/train.py
@@ -54,8 +54,8 @@ def setup_seeds(config):
 def get_paths(dataset_name):
     if dataset_name == "libriasr":
         return {
-            "train": "/home/toolkit/SALMONN/data/IEMOCAP/ie-train-full.json",
-            "test": "/home/toolkit/SALMONN/data/IEMOCAP/ie-test-full.json",
+            "train": "/home/toolkit/SALMONN/data/LibriASR/Librispeech-train-asr.json",
+            "test": "/home/toolkit/SALMONN/data/LibriASR/Librispeech-test-asr.json",
             "valid": "/home/toolkit/SALMONN/data/LibriASR/Librispeech-test-asr.json",
             "data_root": "/mnt/dssk/data_rw/shubham/l2p/libriSQA/",
         }

--- a/train.py
+++ b/train.py
@@ -51,6 +51,29 @@ def setup_seeds(config):
     cudnn.benchmark = False
     cudnn.deterministic = True
 
+def get_paths(dataset_name):
+    if dataset_name == "libriasr":
+        return {
+            "train": "/home/toolkit/SALMONN/data/IEMOCAP/ie-train-full.json",
+            "test": "/home/toolkit/SALMONN/data/IEMOCAP/ie-test-full.json",
+            "valid": "/home/toolkit/SALMONN/data/LibriASR/Librispeech-test-asr.json",
+            "data_root": "/mnt/dssk/data_rw/shubham/l2p/libriSQA/",
+        }
+    if dataset_name == "librisqa":
+        return {
+            "train": "/home/toolkit/SALMONN/data/LibriSQA/LibriSQA-train.json",
+            "test": "/home/toolkit/SALMONN/data/LibriSQA/LibriSQA-test.json",
+            "valid": "/home/toolkit/SALMONN/data/LibriSQA/LibriSQA-test.json",
+            "data_root": "/mnt/dssk/data_rw/shubham/l2p/libriSQA/",
+        }
+    if dataset_name == "er":
+        return {
+            "train": "/home/toolkit/SALMONN/data/IEMOCAP/ie-train-full.json",
+            "test": "/home/toolkit/SALMONN/data/IEMOCAP/ie-test-full.json",
+            "valid": "/home/toolkit/SALMONN/data/IEMOCAP/ie-valid-full.json",
+            "data_root": "users/rwhetten/IEMOCAP/IEMOCAP_full_release/",
+        }
+
 
 def main():
     # set before init_distributed_mode() to ensure the same job_id shared across all ranks.
@@ -72,12 +95,14 @@ def main():
 
     # build model
     model = load_model(model_config)
+    
+    dataset_paths = get_paths(data_config.dataset)
 
     # build datasets
     datasets = {
-        "train": SALMONNDataset(data_config.train_ann_path, data_config.whisper_path, data_config.data_root),
-        "valid": SALMONNDataset(data_config.valid_ann_path, data_config.whisper_path, data_config.data_root),
-        "test": SALMONNDataset(data_config.test_ann_path, data_config.whisper_path, data_config.data_root),
+        "train": SALMONNDataset(dataset_paths["train"], data_config.whisper_path, dataset_paths["data_root"]),
+        "valid": SALMONNDataset(dataset_paths["valid"], data_config.whisper_path, dataset_paths["data_root"]),
+        "test": SALMONNDataset(dataset_paths["test"], data_config.whisper_path, dataset_paths["data_root"]),
     }
 
     # build runner


### PR DESCRIPTION
This PR does following things:
- Sometimes validation takes a long time, so i am limiting it to 25 iterations, with a batch size of 8, it amounts to validation on 200 samples.
- Bring back learning a new pad token if its not present.
- Use evaluate for Bleu and RougeL, but Rouge4 from rouge_scorer as not supported by evaluate, and finally wer.
- Insted of providing all the train, valid and test paths directly in config, it just takes a dataset name (ideally that represents a dataset + task) and then the paths are hard coded in train.py based on this dataset name. Makes launching jobs easier. 
- Add CLOTHO dataset.